### PR TITLE
Initial addition of LEDProjector config

### DIFF
--- a/LEDProjector/v1/_init.yaml
+++ b/LEDProjector/v1/_init.yaml
@@ -1,0 +1,9 @@
+device_type: T4
+connection_type: TCP
+identifier: 127.0.0.1
+topics:
+  - topic_name: ledControllerItem
+    sensor_name: local_ljm
+    led_names: [M375L4]
+    channel_names: [FIO7]
+    location: local_network

--- a/LEDProjector/v1/_tucson.yaml
+++ b/LEDProjector/v1/_tucson.yaml
@@ -1,0 +1,7 @@
+identifier: ledprojectorlj.tu.lsst.org
+topics:
+  - topic_name: ledControllerItem
+    sensor_name: tucson_lab_ljm
+    led_names: [M375L4]
+    channel_names: [FIO7]
+    location: tucson


### PR DESCRIPTION
Already tested on VPN, this connects and operates the LED connected in the Tucson lab.