### PR TITLE
DM-49971: changing LED name in i-band

### DIFF
--- a/LEDProjector/v2/_summit.yaml
+++ b/LEDProjector/v2/_summit.yaml
@@ -4,7 +4,7 @@ identifier: flat-ledprojectorlj.cp.lsst.org
 topics:
   - topic_name: ledControllerItem
     sensor_name: tucson_lab_ljm
-    led_names: [M385L3, M970L4, M455L4, M505L4, M565L3, M660L4, M730L5, M780LP1, M850L3, M940L3]
+    led_names: [M385L3, M970L4, M455L4, M505L4, M565L3, M660L4, M810L3, M780LP1, M850L3, M940L3]
     channel_names: [EIO0, EIO1, EIO2, EIO3, EIO4, EIO5, EIO6, EIO7, CIO0, CIO1]
     dac_mapping: [DAC1, DAC0, DAC1, DAC0, DAC1, DAC0, DAC1, DAC0, DAC1, DAC0]
     location: tucson

--- a/doc/news/DM-49971.feature.rst
+++ b/doc/news/DM-49971.feature.rst
@@ -1,0 +1,1 @@
+Updated LED name for i band: M780LP1 to M810L3


### PR DESCRIPTION
Updating the LEDProject configuration file to document a LED change from M740LP1 to M810L3