### PR TITLE
DM-52696: Added stage serial number to Zaber Linear Stage

### DIFF
--- a/LinearStage/v5/_base.yaml
+++ b/LinearStage/v5/_base.yaml
@@ -6,6 +6,7 @@ instances:
       stage_name: X-MCC4
       hostname: "localhost"
       port: 4001
+      serial_number: 115313
     target_position_minimum: 0
     target_position_maximum: 25
   - sal_index: 102
@@ -15,6 +16,7 @@ instances:
       stage_name: LEDSelector
       hostname: "localhost"
       port: 4001
+      serial_number: 115746
     target_position_minimum: 0
     target_position_maximum: 300
   - sal_index: 103
@@ -24,14 +26,16 @@ instances:
       stage_name: VerticalSelector
       hostname: "localhost"
       port: 4001
+      serial_number: 122462
     target_position_minimum: 0
     target_position_maximum: 150
   - sal_index: 104
     stage_type: ZaberV2
     stage_config:
       daisy_chain_address: 4
-      stage_name: LEDFocus
+      stage_name: LaserFocus
       hostname: "localhost"
       port: 4001
+      serial_number: 139265
     target_position_minimum: 0
     target_position_maximum: 50


### PR DESCRIPTION
I swapped out a stage and realized there wasn't a good way to identify which stage was actually installed.